### PR TITLE
Enable SSE streaming in chat UI

### DIFF
--- a/chat-ui/src/App.tsx
+++ b/chat-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import './App.css'
 import MarkdownIt from 'markdown-it'
 
@@ -26,6 +26,8 @@ function App() {
   const [input, setInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [sseConnected, setSseConnected] = useState(false)
+  const eventSourceRef = useRef<EventSource | null>(null)
 
   // Suggestion prompts
   const suggestions = [
@@ -33,6 +35,32 @@ function App() {
     "What is the retiring date for my models and the recommended replacement?",
     "Update my model to the recommended version"
   ]
+
+  useEffect(() => {
+    const es = new EventSource('http://localhost:8000/api/chat/stream')
+    eventSourceRef.current = es
+
+    es.onopen = () => setSseConnected(true)
+
+    es.onmessage = (ev) => {
+      try {
+        const data: Message = JSON.parse(ev.data)
+        setMessages((prev) => [...prev, data])
+      } catch (err) {
+        console.error('Failed to parse SSE message', err)
+      }
+    }
+
+    es.onerror = (err) => {
+      console.error('SSE connection error', err)
+      setSseConnected(false)
+      es.close()
+    }
+
+    return () => {
+      es.close()
+    }
+  }, [])
 
   const handleSend = async () => {
     if (!input.trim()) return
@@ -64,14 +92,14 @@ function App() {
         throw new Error(errorData.detail || 'Failed to get response from AI')
       }
 
-      const data = await response.json()
-      
-      // Add AI response
-      const aiMessage: Message = {
-        role: 'assistant',
-        content: data.message.content,
+      if (!sseConnected) {
+        const data = await response.json()
+        const aiMessage: Message = {
+          role: 'assistant',
+          content: data.message.content,
+        }
+        setMessages((prev) => [...prev, aiMessage])
       }
-      setMessages((prev) => [...prev, aiMessage])
     } catch (error) {
       console.error('Failed to get response from AI', error)
       setError(error instanceof Error ? error.message : 'An unexpected error occurred')


### PR DESCRIPTION
## Summary
- open a persistent EventSource connection to `/api/chat/stream`
- append streaming messages from the server to the conversation
- fall back to the existing fetch response if SSE is unavailable

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840b81f20688333a50dfd0c08076bb6