### PR TITLE
Use SSE chat endpoint

### DIFF
--- a/chat-ui/src/App.css
+++ b/chat-ui/src/App.css
@@ -245,3 +245,14 @@ th, td {
   outline: none;
   box-shadow: none;
 }
+
+.tool-update {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin: 6px auto;
+  max-width: 90%;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- switch frontend to `/api/chat/stream` SSE endpoint
- parse SSE events and append to UI state
- show tool call updates temporarily

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848834696888333ac0b7dc766ae2751